### PR TITLE
Add support for the Time Echo protocol

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+1.1.0a1
+#######
+- Add :py:mod:`pupil_labs.realtime_api.clock_echo`
+
 1.0.0.post1
 ###########
 - Improve front-page documentation

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,16 @@
+1.1.0
+#####
+
+- Rename ``pupil_labs.realtime_api.clock_echo`` to :py:mod:`pupil_labs.realtime_api.time_echo`
+  and all corresponding class and function prefixes.
+
 1.1.0a2
 #######
 - Internal feature
 
 1.1.0a1
 #######
-- Add :py:mod:`pupil_labs.realtime_api.clock_echo`
+- Add ``pupil_labs.realtime_api.clock_echo``
 
 1.0.1
 #####

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+1.1.0a2
+#######
+- Internal feature
+
 1.1.0a1
 #######
 - Add :py:mod:`pupil_labs.realtime_api.clock_echo`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Rename ``pupil_labs.realtime_api.clock_echo`` to :py:mod:`pupil_labs.realtime_api.time_echo`
   and all corresponding class and function prefixes.
+- Expose Time Echo port via :py:attr:`pupil_labs.realtime_api.models.Phone.time_echo_port`
 
 1.1.0a2
 #######

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Rename ``pupil_labs.realtime_api.clock_echo`` to :py:mod:`pupil_labs.realtime_api.time_echo`
   and all corresponding class and function prefixes.
 - Expose Time Echo port via :py:attr:`pupil_labs.realtime_api.models.Phone.time_echo_port`
+- Add simple API to estimate time offset :py:func:`pupil_labs.realtime_api.simple.Device.estimate_time_offset`
+- Add simple and async time offset estimation examples
 
 1.1.0a2
 #######

--- a/docs/api/async.rst
+++ b/docs/api/async.rst
@@ -49,10 +49,10 @@ Raw RTSP Data
     :show-inheritance:
     :private-members:
 
-Clock Synchronization
-=====================
+Time Echo Protocol
+==================
 
-.. automodule:: pupil_labs.realtime_api.clock_echo
+.. automodule:: pupil_labs.realtime_api.time_echo
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/api/async.rst
+++ b/docs/api/async.rst
@@ -48,3 +48,11 @@ Raw RTSP Data
     :undoc-members:
     :show-inheritance:
     :private-members:
+
+Clock Synchronization
+=====================
+
+.. automodule:: pupil_labs.realtime_api.clock_echo
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,8 @@ nitpick_ignore = [
     ("py:class", "nptyping.types._ndarray.NDArray"),
     ("py:class", "nptyping.types._number.UInt"),
     ("py:class", "aiortsp.rtsp.reader.RTSPReader"),
+    ("py:class", "asyncio.streams.StreamReader"),
+    ("py:class", "asyncio.streams.StreamWriter"),
 ]
 
 

--- a/docs/examples/async.rst
+++ b/docs/examples/async.rst
@@ -97,6 +97,8 @@ Device Discovery
 Time Offset Estimation
 ======================
 
+See :py:mod:`pupil_labs.realtime_api.time_echo` for details.
+
 .. literalinclude:: ../../examples/async/device_time_offset.py
    :language: python
    :emphasize-lines: 18,27-31,34

--- a/docs/examples/async.rst
+++ b/docs/examples/async.rst
@@ -93,3 +93,11 @@ Device Discovery
    :language: python
    :emphasize-lines: 8,10,15,20
    :linenos:
+
+Time Offset Estimation
+======================
+
+.. literalinclude:: ../../examples/async/device_time_offset.py
+   :language: python
+   :emphasize-lines: 18,27-31,34
+   :linenos:

--- a/docs/examples/simple.rst
+++ b/docs/examples/simple.rst
@@ -88,3 +88,13 @@ Scene camera video with overlayed gaze
    :language: python
    :emphasize-lines: 18,20,21
    :linenos:
+
+Time Offset Estimation
+======================
+
+See :py:mod:`pupil_labs.realtime_api.time_echo` for details.
+
+.. literalinclude:: ../../examples/simple/device_time_offset.py
+   :language: python
+   :emphasize-lines: 9,14,15
+   :linenos:

--- a/examples/async/device_time_offset.py
+++ b/examples/async/device_time_offset.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from pupil_labs.realtime_api import Device, Network
+from pupil_labs.realtime_api.time_echo import TimeOffsetEstimator
+
+
+async def main():
+    async with Network() as network:
+        dev_info = await network.wait_for_new_device(timeout_seconds=5)
+    if dev_info is None:
+        print("No device could be found! Abort")
+        return
+
+    async with Device.from_discovered_device(dev_info) as device:
+        status = await device.get_status()
+
+        print(f"Device IP address: {status.phone.ip}")
+        print(f"Device Time Echo port: {status.phone.time_echo_port}")
+
+        if status.phone.time_echo_port is None:
+            print(
+                "You Pupil Invisible Companion app is out-of-date and does not yet "
+                "support the Time Echo protocol. Upgrade to version 1.4.28 or newer."
+            )
+            return
+
+        time_offset_estimator = TimeOffsetEstimator(
+            status.phone.ip, status.phone.time_echo_port
+        )
+        estimated_offset = await time_offset_estimator.estimate()
+        print(f"Mean time offset: {estimated_offset.time_offset_ms.mean} ms")
+        print(
+            "Mean roundtrip duration: "
+            f"{estimated_offset.roundtrip_duration_ms.mean} ms"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/simple/device_time_offset.py
+++ b/examples/simple/device_time_offset.py
@@ -1,0 +1,17 @@
+from pupil_labs.realtime_api.simple import discover_one_device
+
+# Look for devices. Returns as soon as it has found the first device.
+print("Looking for the next best device...")
+device = discover_one_device(max_search_duration_seconds=10)
+if device is None:
+    raise SystemExit("No device found.")
+
+estimate = device.estimate_time_offset()
+if estimate is None:
+    device.close()
+    raise SystemExit("Pupil Companion app is too old")
+
+print(f"Mean time offset: {estimate.time_offset_ms.mean} ms")
+print(f"Mean roundtrip duration: {estimate.roundtrip_duration_ms.mean} ms")
+
+device.close()

--- a/src/pupil_labs/realtime_api/clock_echo.py
+++ b/src/pupil_labs/realtime_api/clock_echo.py
@@ -1,0 +1,188 @@
+"""Manual clock offset estimation via the Pupil Labs Clock Echo protocol
+
+The Realtime Network API host device timestamps its data with nanoseconds since the
+`Unix epoch`_ (January 1, 1970, 00:00:00 UTC). This clock is kept in sync by the
+operating system through `NTP`_ (Network Time Protocol). For some use cases, this sync
+is not good enough. For more accurate time syncs, the Clock Echo protocol allows the
+estimation of the direct offset between the host's and the client's clocks.
+
+.. _Unix epoch: https://docs.python.org/3/library/time.html#epoch
+.. _NTP: https://en.wikipedia.org/wiki/Network_Time_Protocol#
+   Clock_synchronization_algorithm
+
+The Clock Echo protocol works in the following way:
+
+1. The API host (Pupil Invisible Companion app) opens a TCP server at a specific port
+2. The client connects to the host address and port
+3. The client sends its current time (``t1``) in milliseconds as an uint64 in network
+   byte order to the host
+4. The host responds with the clock echo, two uint64 values in network byte order
+   1. The first value is equal to the sent client time (``t1``)
+   2. The second value corresponds to the host's time in milliseconds (``tH``)
+5. The client calculates the duration of steps 3 and 4 (roundtrip time) by measuring the
+   client time before sending the request (``t1``) and after receiving the echo (``t2``)
+6. The protocol assumes that the transport duration is symmetric. It will assume that
+   ``tH`` was measured at the same time as the midpoint betwee ``t1`` and ``t2``.
+7. To calculate the offset between the host's and client's clock, we subtract ``tH``
+   from the client's midpoint ``(t1 + t2) / 2``::
+
+      offset_ms = ((t1 + t2) / 2) - tH
+
+8. This measurement can be repeated multiple times to make the clock offset estimation
+   more robust.
+
+To convert client to host time, subtract the offset::
+
+   host_time_ms = client_time_ms() - offset_ms
+
+This is particularly helpful to accurately timestamp local events, e.g. a stimulus
+presentation.
+
+To convert host to client time, add the offset::
+
+   client_time_ms = host_time_ms() + offset_ms
+
+This is particularly helpful to convert the received data into the client's time domain.
+
+----
+"""
+
+import asyncio
+import collections
+import logging
+import statistics
+import struct
+from time import time_ns
+from typing import Callable, Iterable, NamedTuple, Optional
+
+logger = logging.getLogger(__name__)
+
+ClockFunction = Callable[[], int]
+"""Returns time in milliseconds"""
+
+
+class ClockEcho(NamedTuple):
+    """Measurement of a single clock echo"""
+
+    roundtrip_duration_ms: int
+    "Round trip duration of the clock echo, in milliseconds"
+    clock_offset_ms: int
+    "Clock offset between host and client, in milliseconds"
+
+
+class Estimate(NamedTuple):
+    """Provides easy access to statistics over a collection of measurements"""
+
+    measurements: Iterable[int]
+
+    def mean(self) -> float:
+        return statistics.mean(self.measurements)
+
+    def std(self) -> float:
+        return statistics.stdev(self.measurements)
+
+    def median(self) -> float:
+        return statistics.median(self.measurements)
+
+
+class ClockEchoEstimates:
+    """Provides estimates for the roundtrip duration and clock offsets"""
+
+    roundtrip_duration_ms: Estimate
+    clock_offset_ms: Estimate
+
+
+def time_ms():
+    """Return milliseconds since `Unix epoch`_ (January 1, 1970, 00:00:00 UTC)"""
+    return time_ns() // 1_000_000
+
+
+class ClockOffsetEstimator:
+    def __init__(self, address: str, port: int) -> None:
+        self.address = address
+        self.port = port
+
+    async def estimate(
+        self,
+        number_of_measurements: int = 100,
+        sleep_between_measurements_seconds: Optional[float] = None,
+        clock_ms: ClockFunction = time_ms,
+    ) -> Optional[ClockEchoEstimates]:
+        measurements = collections.defaultdict(list)
+
+        try:
+            logger.info(f"Connecting to {self.address}:{self.port}...")
+            reader, writer = await asyncio.open_connection(self.address, self.port)
+
+            rt, offset = self.request_clock_echo(clock_ms, reader, writer)
+            logger.info(
+                f"Dropping first measurement (roundtrip: {rt} ms, offset: {offset} ms)"
+            )
+            logger.info(f"Measuring {number_of_measurements} times...")
+            for _ in range(number_of_measurements):
+                try:
+                    rt, offset = self.request_clock_echo(clock_ms, reader, writer)
+                    measurements["roundtrip"].append(rt)
+                    measurements["offset"].append(offset)
+                    if sleep_between_measurements_seconds is not None:
+                        await asyncio.sleep(sleep_between_measurements_seconds)
+                except ValueError as err:
+                    logger.warning(err)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+        estimates = ClockEchoEstimates(
+            roundtrip_duration_ms=Estimate(measurements["roundtrip"]),
+            clock_offset_ms=Estimate(measurements["offset"]),
+        )
+
+        try:
+            logger.debug(
+                "Roundtrip (mean ± std): "
+                f"{estimates.roundtrip_duration_ms.mean():8.3f} ± "
+                f"{estimates.roundtrip_duration_ms.std:6.3f} ms"
+            )
+            logger.debug(
+                "   Offset (mean ± std): "
+                f"{estimates.clock_offset_ms.mean():8.3f} ± "
+                f"{estimates.clock_offset_ms.std:6.3f} ms"
+            )
+        except statistics.StatisticsError:
+            logger.error("No valid samples were collected")
+            return None
+
+        return estimates
+
+    @staticmethod
+    async def request_clock_echo(
+        clock_ms: ClockFunction,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> ClockEcho:
+        """Request a clock echo, measure the roundtrip time, and estimate the clock
+        offset
+        """
+        before_ms = clock_ms()
+        before_ms_bytes = struct.pack("!Q", before_ms)
+        writer.write(before_ms_bytes)
+        await writer.drain()
+        validation_server_ms_bytes = await reader.read(16)
+        after_ms = clock_ms()
+        if len(validation_server_ms_bytes) != 16:
+            raise ValueError(
+                "Dropping invalid measurement. Expected response of length 16 "
+                f"(got {len(validation_server_ms_bytes)})"
+            )
+        validation_ms, server_ms = struct.unpack("!QQ", validation_server_ms_bytes)
+        logger.debug(
+            f"Response: {validation_ms} {server_ms} ({validation_server_ms_bytes!r})"
+        )
+        if validation_ms != before_ms:
+            raise ValueError(
+                "Dropping invalid measurement. Expected validation timestamp: "
+                f"{before_ms} (got {validation_ms})"
+            )
+        server_ts_in_client_time_ms = round((before_ms + after_ms) / 2)
+        offset_ms = server_ts_in_client_time_ms - server_ms
+        return (after_ms - before_ms, offset_ms)

--- a/src/pupil_labs/realtime_api/models.py
+++ b/src/pupil_labs/realtime_api/models.py
@@ -155,7 +155,7 @@ _model_class_map: T.Dict[str, T.Type[Component]] = {
 
 
 def _init_cls_with_annotated_fields_only(cls, d: T.Dict[str, T.Any]):
-    return cls(**{attr: d[attr] for attr in cls.__annotations__})
+    return cls(**{attr: d.get(attr, None) for attr in cls.__annotations__})
 
 
 class UnknownComponentError(ValueError):
@@ -199,8 +199,9 @@ class Status:
         for dct in status_json_result:
             try:
                 component = parse_component(dct)
-            except UnknownComponentError:
-                logger.warning(f"Dropping unknown component: {component}")
+            except UnknownComponentError as err:
+                logger.warning(f"Dropping unknown component: {dct}")
+                raise
                 continue
             if isinstance(component, Phone):
                 phone = component

--- a/src/pupil_labs/realtime_api/models.py
+++ b/src/pupil_labs/realtime_api/models.py
@@ -199,9 +199,8 @@ class Status:
         for dct in status_json_result:
             try:
                 component = parse_component(dct)
-            except UnknownComponentError as err:
+            except UnknownComponentError:
                 logger.warning(f"Dropping unknown component: {dct}")
-                raise
                 continue
             if isinstance(component, Phone):
                 phone = component

--- a/src/pupil_labs/realtime_api/models.py
+++ b/src/pupil_labs/realtime_api/models.py
@@ -73,6 +73,7 @@ class Phone(T.NamedTuple):
     ip: str
     memory: int
     memory_state: Literal["OK", "LOW", "CRITICAL"]
+    time_echo_port: T.Optional[int] = None
 
 
 class Hardware(T.NamedTuple):
@@ -183,6 +184,7 @@ def parse_component(raw: ComponentRaw) -> Component:
 
 @dataclasses.dataclass
 class Status:
+    "Represents the Companion's full status"
     phone: Phone
     hardware: Hardware
     sensors: T.List[Sensor]

--- a/src/pupil_labs/realtime_api/streaming/gaze.py
+++ b/src/pupil_labs/realtime_api/streaming/gaze.py
@@ -1,8 +1,16 @@
 import datetime
+import logging
 import struct
 import typing as T
 
 from .base import RTSPData, RTSPRawStreamer
+
+logger = logging.getLogger(__name__)
+
+
+class Point(T.NamedTuple):
+    x: float
+    y: float
 
 
 class GazeData(T.NamedTuple):
@@ -25,13 +33,48 @@ class GazeData(T.NamedTuple):
         return int(self.timestamp_unix_seconds * 1e9)
 
 
-async def receive_gaze_data(url, *args, **kwargs) -> T.AsyncIterator[GazeData]:
+class DualMonocularGazeData(T.NamedTuple):
+    left: Point
+    right: Point
+    worn: bool
+    timestamp_unix_seconds: float
+
+    @classmethod
+    def from_raw(cls, data: RTSPData) -> "GazeData":
+        x1, y1, worn, x2, y2 = struct.unpack("!ffBff", data.raw)
+        return cls(
+            Point(x1, y1), Point(x2, y2), worn == 255, data.timestamp_unix_seconds
+        )
+
+    @property
+    def datetime(self):
+        return datetime.datetime.fromtimestamp(self.timestamp_unix_seconds)
+
+    @property
+    def timestamp_unix_ns(self):
+        return int(self.timestamp_unix_seconds * 1e9)
+
+
+async def receive_gaze_data(
+    url, *args, **kwargs
+) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData]]:
     async with RTSPGazeStreamer(url, *args, **kwargs) as streamer:
         async for datum in streamer.receive():
             yield datum
 
 
 class RTSPGazeStreamer(RTSPRawStreamer):
-    async def receive(self) -> T.AsyncIterator[GazeData]:
+    async def receive(
+        self,
+    ) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData]]:
+        data_class_by_raw_len = {9: GazeData, 17: DualMonocularGazeData}
         async for data in super().receive():
-            yield GazeData.from_raw(data)
+            try:
+                cls = data_class_by_raw_len[len(data.raw)]
+                yield cls.from_raw(data)
+            except KeyError:
+                logger.exception(f"Raw gaze data has unexpected length: {data}")
+                raise
+            except Exception:
+                logger.exception(f"Unable to parse gaze data {data}")
+                raise


### PR DESCRIPTION
The Time Echo protocol can be used to estimate the time offset between the host and client devices, similar to the NTP protocol.