### PR TITLE
Fix naming of timestamp_unix_ns field

### DIFF
--- a/src/pupil_labs/realtime_api/streaming/imu.py
+++ b/src/pupil_labs/realtime_api/streaming/imu.py
@@ -24,7 +24,7 @@ class IMUData(T.NamedTuple):
     gyro_data: Data3D
     accel_data: Data3D
     quaternion: Quaternion
-    timestamp_unix_nanoseconds: float
+    timestamp_unix_ns: float
     timestamp_unix_seconds: float
 
 


### PR DESCRIPTION
Changed `timestamp_unix_nanoseconds` to `timestamp_unix_ns` to be consistent with the other sensors