### PR TITLE
Add EyestateGazeData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+1.2.0
+###########
+- Add support for streaming eye state data from Neon Companion app (2.8.8+)
+
+    - :py:class:`pupil_labs.realtime_api.streaming.gaze.EyestateGazeData`
+
 1.1.2
 ###########
 - Add support for streaming eyes video from Neon Companion app

--- a/src/pupil_labs/realtime_api/simple/models.py
+++ b/src/pupil_labs/realtime_api/simple/models.py
@@ -1,7 +1,7 @@
 import datetime
 import typing as T
 
-from ..streaming.gaze import GazeData
+from ..streaming.gaze import DualMonocularGazeData, EyestateGazeData, GazeData
 from ..streaming.video import BGRBuffer, VideoFrame
 
 
@@ -34,7 +34,7 @@ class MatchedItem(T.NamedTuple):
 class MatchedGazeEyesSceneItem(T.NamedTuple):
     scene: SimpleVideoFrame
     eyes: SimpleVideoFrame
-    gaze: GazeData
+    gaze: GazeData | DualMonocularGazeData | EyestateGazeData
 
 
 MATCHED_ITEM_LABEL = "matched_gaze_and_scene_video"

--- a/src/pupil_labs/realtime_api/streaming/gaze.py
+++ b/src/pupil_labs/realtime_api/streaming/gaze.py
@@ -56,6 +56,38 @@ class DualMonocularGazeData(T.NamedTuple):
     def timestamp_unix_ns(self):
         return int(self.timestamp_unix_seconds * 1e9)
 
+class EyestateGazeData(T.NamedTuple):
+    x: float
+    y: float
+    worn: bool
+    pupil_diam_left: float
+    eyeball_center_left_x: float
+    eyeball_center_left_y: float
+    eyeball_center_left_z: float
+    optical_axis_left_x: float
+    optical_axis_left_y: float
+    optical_axis_left_z: float
+    pupil_diam_right: float
+    eyeball_center_right_x: float
+    eyeball_center_right_y: float
+    eyeball_center_right_z: float
+    optical_axis_right_x: float
+    optical_axis_right_y: float
+    optical_axis_right_z: float
+    timestamp_unix_seconds: float
+
+    @classmethod
+    def from_raw(cls, data: RTSPData) -> "EyestateGazeData":
+        x, y, worn, es0, es1, es2, es3, es4, es5, es6, es7, es8, es9, es10, es11, es12, es13 = struct.unpack("!ffBffffffffffffff", data.raw)
+        return cls(x, y, worn == 255, es0, es1, es2, es3, es4, es5, es6, es7, es8, es9, es10, es11, es12, es13, data.timestamp_unix_seconds)
+
+    @property
+    def datetime(self):
+        return datetime.datetime.fromtimestamp(self.timestamp_unix_seconds)
+
+    @property
+    def timestamp_unix_ns(self):
+        return int(self.timestamp_unix_seconds * 1e9)
 
 async def receive_gaze_data(
     url, *args, **kwargs
@@ -69,7 +101,7 @@ class RTSPGazeStreamer(RTSPRawStreamer):
     async def receive(
         self,
     ) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData]]:
-        data_class_by_raw_len = {9: GazeData, 17: DualMonocularGazeData}
+        data_class_by_raw_len = {9: GazeData, 17: DualMonocularGazeData, 65: EyestateGazeData}
         async for data in super().receive():
             try:
                 cls = data_class_by_raw_len[len(data.raw)]

--- a/src/pupil_labs/realtime_api/streaming/gaze.py
+++ b/src/pupil_labs/realtime_api/streaming/gaze.py
@@ -56,6 +56,7 @@ class DualMonocularGazeData(T.NamedTuple):
     def timestamp_unix_ns(self):
         return int(self.timestamp_unix_seconds * 1e9)
 
+
 class EyestateGazeData(T.NamedTuple):
     x: float
     y: float
@@ -78,8 +79,45 @@ class EyestateGazeData(T.NamedTuple):
 
     @classmethod
     def from_raw(cls, data: RTSPData) -> "EyestateGazeData":
-        x, y, worn, es0, es1, es2, es3, es4, es5, es6, es7, es8, es9, es10, es11, es12, es13 = struct.unpack("!ffBffffffffffffff", data.raw)
-        return cls(x, y, worn == 255, es0, es1, es2, es3, es4, es5, es6, es7, es8, es9, es10, es11, es12, es13, data.timestamp_unix_seconds)
+        (
+            x,
+            y,
+            worn,
+            es0,
+            es1,
+            es2,
+            es3,
+            es4,
+            es5,
+            es6,
+            es7,
+            es8,
+            es9,
+            es10,
+            es11,
+            es12,
+            es13,
+        ) = struct.unpack("!ffBffffffffffffff", data.raw)
+        return cls(
+            x,
+            y,
+            worn == 255,
+            es0,
+            es1,
+            es2,
+            es3,
+            es4,
+            es5,
+            es6,
+            es7,
+            es8,
+            es9,
+            es10,
+            es11,
+            es12,
+            es13,
+            data.timestamp_unix_seconds,
+        )
 
     @property
     def datetime(self):
@@ -88,6 +126,7 @@ class EyestateGazeData(T.NamedTuple):
     @property
     def timestamp_unix_ns(self):
         return int(self.timestamp_unix_seconds * 1e9)
+
 
 async def receive_gaze_data(
     url, *args, **kwargs
@@ -101,7 +140,11 @@ class RTSPGazeStreamer(RTSPRawStreamer):
     async def receive(
         self,
     ) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData]]:
-        data_class_by_raw_len = {9: GazeData, 17: DualMonocularGazeData, 65: EyestateGazeData}
+        data_class_by_raw_len = {
+            9: GazeData,
+            17: DualMonocularGazeData,
+            65: EyestateGazeData,
+        }
         async for data in super().receive():
             try:
                 cls = data_class_by_raw_len[len(data.raw)]

--- a/src/pupil_labs/realtime_api/streaming/gaze.py
+++ b/src/pupil_labs/realtime_api/streaming/gaze.py
@@ -61,14 +61,14 @@ class EyestateGazeData(T.NamedTuple):
     x: float
     y: float
     worn: bool
-    pupil_diam_left: float
+    pupil_diameter_left: float
     eyeball_center_left_x: float
     eyeball_center_left_y: float
     eyeball_center_left_z: float
     optical_axis_left_x: float
     optical_axis_left_y: float
     optical_axis_left_z: float
-    pupil_diam_right: float
+    pupil_diameter_right: float
     eyeball_center_right_x: float
     eyeball_center_right_y: float
     eyeball_center_right_z: float
@@ -83,39 +83,39 @@ class EyestateGazeData(T.NamedTuple):
             x,
             y,
             worn,
-            es0,
-            es1,
-            es2,
-            es3,
-            es4,
-            es5,
-            es6,
-            es7,
-            es8,
-            es9,
-            es10,
-            es11,
-            es12,
-            es13,
+            pupil_diameter_left,
+            eyeball_center_left_x,
+            eyeball_center_left_y,
+            eyeball_center_left_z,
+            optical_axis_left_x,
+            optical_axis_left_y,
+            optical_axis_left_z,
+            pupil_diam_right,
+            eyeball_center_right_x,
+            eyeball_center_right_y,
+            eyeball_center_right_z,
+            optical_axis_right_x,
+            optical_axis_right_y,
+            optical_axis_right_z,
         ) = struct.unpack("!ffBffffffffffffff", data.raw)
         return cls(
             x,
             y,
             worn == 255,
-            es0,
-            es1,
-            es2,
-            es3,
-            es4,
-            es5,
-            es6,
-            es7,
-            es8,
-            es9,
-            es10,
-            es11,
-            es12,
-            es13,
+            pupil_diameter_left,
+            eyeball_center_left_x,
+            eyeball_center_left_y,
+            eyeball_center_left_z,
+            optical_axis_left_x,
+            optical_axis_left_y,
+            optical_axis_left_z,
+            pupil_diam_right,
+            eyeball_center_right_x,
+            eyeball_center_right_y,
+            eyeball_center_right_z,
+            optical_axis_right_x,
+            optical_axis_right_y,
+            optical_axis_right_z,
             data.timestamp_unix_seconds,
         )
 
@@ -130,7 +130,7 @@ class EyestateGazeData(T.NamedTuple):
 
 async def receive_gaze_data(
     url, *args, **kwargs
-) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData]]:
+) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData, EyestateGazeData]]:
     async with RTSPGazeStreamer(url, *args, **kwargs) as streamer:
         async for datum in streamer.receive():
             yield datum
@@ -139,7 +139,7 @@ async def receive_gaze_data(
 class RTSPGazeStreamer(RTSPRawStreamer):
     async def receive(
         self,
-    ) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData]]:
+    ) -> T.AsyncIterator[T.Union[GazeData, DualMonocularGazeData, EyestateGazeData]]:
         data_class_by_raw_len = {
             9: GazeData,
             17: DualMonocularGazeData,


### PR DESCRIPTION
Support streaming of eyestate data. Backwards compatible to gaze data-only clients with older versions or with disabled eyestate.