### PR TITLE
Do not require the server to echo the interleaved header

### DIFF
--- a/vendor/aiortsp/aiortsp/transport/tcp.py
+++ b/vendor/aiortsp/aiortsp/transport/tcp.py
@@ -72,7 +72,18 @@ class TCPTransport(RTPTransport):
 
         fields = self.parse_transport_fields(headers['transport'])
 
-        assert fields.get('interleaved') == f'{self.rtp_idx}-{self.rtcp_idx}', 'invalid returned interleaved header'
+        interleaved = fields.get('interleaved')
+        if interleaved is None:
+            self.logger.debug(
+                "server did not echo interleaved channels, keeping requested %s-%s",
+                self.rtp_idx,
+                self.rtcp_idx,
+            )
+            return
+        else:
+            assert interleaved == f"{self.rtp_idx}-{self.rtcp_idx}", (
+                f"server returned invalid interleaved header '{interleaved}'"
+            )
 
     async def send_rtcp_report(self, rtcp: RTCP):
         self.connection.send_binary(self.rtcp_idx, bytes(rtcp))


### PR DESCRIPTION
I am using Neon Companion `2.9.31-prod`. I am forcing TCP transport by using `rtspt://...` urls, the server does not echo back the `interleaved` header leading to the assertion being triggered, breaking the code.

This PR fixes this by skips the assertion if the server did not echo the `interleaved` header. According to https://www.ietf.org/rfc/rfc2326#page-58 it does not seem mandatory for the server to echo back the headers:

>    Parameters may be added to each transport, separated by a semicolon.
> 
>    The Transport header MAY also be used to change certain transport
>    parameters. A server MAY refuse to change parameters of an existing
>    stream.
> 
>    The server MAY return a Transport response header in the response to
>    indicate the values actually chosen.