### PR TITLE
Workaround for Neon Companion RTSP Server bug when streaming over TCP

### DIFF
--- a/vendor/aiortsp/aiortsp/transport/base.py
+++ b/vendor/aiortsp/aiortsp/transport/base.py
@@ -138,7 +138,10 @@ class RTPTransport:
 
             try:
                 self.logger.debug('sending RTCP report: %s', rtcp)
-                await self.send_rtcp_report(rtcp)
+                # ! Workaround for Neon Companion RTSP Server: it can respond with
+                # ! "RTSP/1.0 400 Bad Request ..." inside the interleaved RTP
+                # ! byte stream after client RTCP reports, corrupting framing.
+                # await self.send_rtcp_report(rtcp)
             except asyncio.CancelledError:
                 break
             except Exception as ex:  # pylint: disable=broad-except


### PR DESCRIPTION
Hi,

This draft is just for reference for anyone that might be streaming data over TCP that runs into what seems to be a bug on the Pupil RTSP Server (inside the Companion app).

I am in touch with Pupil Labs via a Discord ticket regarding this issue.

---

What I am doing:
- streaming all sensors data via the python pupil labs realtime package
- direct RTSP streams forced to `rtspt://`. I need to use TCP transport instead of UDP because at least the video frames get corrupted over my network when using UDP.
- the RTSP server (on the Companion App) injects `RTSP/1.0 400 Bad Request [... the rest of the info...]` inside an interleaved RTP frame. This corrupts the RTP packets and `aiortsp` rightfully raises a value error:

```python
Traceback (most recent call last):
  File "/path/to/my/venv/lib/python3.13/site-packages/aiortsp/rtsp/connection.py", line 150, in data_received
    for msg in self.parser.parse(data):
               ~~~~~~~~~~~~~~~~~^^^^^^
  File "/path/to/my/venv/lib/python3.13/site-packages/aiortsp/rtsp/parser.py", line 351, in parse
    raise ValueError
```

Usually the byte stream starts as valid RTSP interleaved RTP packets:

```
00 04 f8 80 60 ...
```

But after several valid packets, the server sends this inside the place where the next RTP payload should begin:

```
00 04 f8 RTSP/1.0 400 Bad Request
Server: Pupil Invisible RTSP Server
Content-Length: 0

80 60 ...
```

in the more raw form you see in the raised error e.g. `... \xeb\x99[k\xe0\x9b\xc3$\x00\x04\xf8RTSP/1.0 400 Bad Request\r\nServer: Pupil Invisible RTSP Server\r\nContent-Length: 0\r\n\r\n\x80 ...`

This seems to be an issue of how the Neon Companion App server responds to RTCP reports sent by the `aiortsp` client. As a temporary workaround disabling these reports with this patch seems to solve the issue.